### PR TITLE
Uses cart property directly and stops wondering if it exists or not

### DIFF
--- a/tests/DestroyCartTest.php
+++ b/tests/DestroyCartTest.php
@@ -51,19 +51,6 @@ class DestroyCartTest extends TestCase
         $this->assertTrue(Cart::doesNotExist());
     }
 
-    /**
-     * @test
-     */
-    public function cart_does_not_have_a_model_after_destroy()
-    {
-        Cart::addItem($this->product8);
-
-        $this->assertInstanceOf(CartContract::class, Cart::model());
-
-        Cart::destroy();
-        $this->assertNull(Cart::model());
-    }
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/NonexistentCartTest.php
+++ b/tests/NonexistentCartTest.php
@@ -22,7 +22,6 @@ class NonexistentCartTest extends TestCase
     public function the_cart_facade_returns_a_nonexistent_cart_by_default()
     {
         $this->assertTrue(Cart::doesNotExist());
-        $this->assertNull(Cart::model());
     }
 
     /**


### PR DESCRIPTION
Hi there, 
I'm working on a small e-commerce site for a client and I found myself looking for inspiration and stumbled upon your project. 

I'm not using the vanilophp framework yet (still getting familiar with concord) but I am picking some pieces from here and there and I thought I should share any possible improvements/additions/fixes I might find.

-------
The PR:  

Removes the whole wondering if the cart exists and calls it directly, so no more "if exists" statements.

Doesn't go around and starts creating cart database records but when `removeItem(), removeProduct(), clear(), itemCount(), total(), delete()` are called, the queries are indeed executed (using `cart_id = null`) even if the cart record isn't yet created.

But, I don't see how these methods will be called if no cart is yet created.

If you do think there's a use-case for that but still like the idea, we could add a nullable cart object that will prevent touching the database.

If you don't like the idea at all, feel free to turn down the pr - I thought it's worth sharing.